### PR TITLE
Fix the builtins and M3 jsons 

### DIFF
--- a/metametamodel/builtins.json
+++ b/metametamodel/builtins.json
@@ -4,6 +4,10 @@
     {
       "key": "LionCore-M3",
       "version": "2023.1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
     }
   ],
   "nodes": [
@@ -29,7 +33,7 @@
             "version": "2023.1",
             "key": "Language-version"
           },
-          "value": "1"
+          "value": "2023.1"
         },
         {
           "property": {

--- a/metametamodel/lioncore.json
+++ b/metametamodel/lioncore.json
@@ -4,6 +4,10 @@
     {
       "key": "LionCore-M3",
       "version": "2023.1"
+    },
+    {
+      "key": "LionCore-builtins",
+      "version": "2023.1"
     }
   ],
   "nodes": [
@@ -29,7 +33,7 @@
             "version": "2023.1",
             "key": "Language-version"
           },
-          "value": "1"
+          "value": "2023.1"
         },
         {
           "property": {


### PR DESCRIPTION
In the json for M2 and builtins:

- builtins was missing as used language => added
- language-version was "1", changed to "2023.1"