### PR TITLE
Explain why the composite command and event have suffixes

### DIFF
--- a/delta/commands.adoc
+++ b/delta/commands.adoc
@@ -1361,5 +1361,10 @@ We can nest composite commands arbitrarily.{fn-org360}
 .Technical name
 `CompositeCommand`
 
+****
+This command is the only one to have a `Command` suffix, which is necessary to distinguish it from its <<evnt-CompositeEvent, `CompositeEvent`>> counterpart.
+All other commands can be distinguished from their event counterparts by looking at whether the technical name reads as an imperative (“add child” — for commands), or in past perfect tense (”child [has been] added” — for events).
+****
+
 .Related event
 <<evnt-CompositeEvent>>

--- a/delta/commands.adoc
+++ b/delta/commands.adoc
@@ -1359,12 +1359,10 @@ We can nest composite commands arbitrarily.{fn-org360}
 * <<err-invalidParticipation>>
 
 .Technical name
-`CompositeCommand`
-
-****
+`CompositeCommand` footnote:[
 This command is the only one to have a `Command` suffix, which is necessary to distinguish it from its <<evnt-CompositeEvent, `CompositeEvent`>> counterpart.
-All other commands can be distinguished from their event counterparts by looking at whether the technical name reads as an imperative (“add child” — for commands), or in past perfect tense (”child [has been] added” — for events).
-****
+All other commands can be distinguished from their event counterparts by looking at whether the technical name reads as an imperative (“add child” — for commands), or in past perfect tense (”child [has been\] added” — for events).
+]
 
 .Related event
 <<evnt-CompositeEvent>>

--- a/delta/events.adoc
+++ b/delta/events.adoc
@@ -985,13 +985,11 @@ We can nest composite events arbitrarily.{fn-org360}
 [[CompositeEvent.protocolMessages]]protocolMessages:: <<protocolMessagesType>>
 
 .Technical name
-`CompositeEvent`
-
-****
+`CompositeEvent` footnote:[
 This event is the only one to have a `Event` suffix, which is necessary to distinguish it from its <<cmd-CompositeCommand, `CompositeCommand`>> counterpart.
-All other events can be distinguished from their command counterparts by looking at whether the technical name reads as an imperative (“add child” — for commands), or in past perfect tense (”child [has been] added” — for events).
+All other events can be distinguished from their command counterparts by looking at whether the technical name reads as an imperative (“add child” — for commands), or in past perfect tense (”child [has been\] added” — for events).
 (The <<evnt-NoOp, `NoOp`>> and <<evnt-Error, `Error`>> don't have command counterparts.)
-****
+]
 
 .Related command
 <<cmd-CompositeCommand>>

--- a/delta/events.adoc
+++ b/delta/events.adoc
@@ -987,22 +987,27 @@ We can nest composite events arbitrarily.{fn-org360}
 .Technical name
 `CompositeEvent`
 
+****
+This event is the only one to have a `Event` suffix, which is necessary to distinguish it from its <<cmd-CompositeCommand, `CompositeCommand`>> counterpart.
+All other events can be distinguished from their command counterparts by looking at whether the technical name reads as an imperative (“add child” — for commands), or in past perfect tense (”child [has been] added” — for events).
+(The <<evnt-NoOp, `NoOp`>> and <<evnt-Error, `Error`>> don't have command counterparts.)
+****
+
 .Related command
 <<cmd-CompositeCommand>>
 
 [[evnt-NoOp]]
-[[evnt-NoOpEvent]]
 ===== No-op
 Nothing happened as result of one or more command(s).{fn-org314}
 
 [horizontal]
 .Parameters
-[[NoOpEvent.originCommands]]originCommands:: <<commandSourceType>>[]
-[[NoOpEvent.sequenceNumber]]sequenceNumber:: <<event-sequence-number>>
-[[NoOpEvent.protocolMessages]]protocolMessages:: <<protocolMessagesType>>
+[[NoOp.originCommands]]originCommands:: <<commandSourceType>>[]
+[[NoOp.sequenceNumber]]sequenceNumber:: <<event-sequence-number>>
+[[NoOp.protocolMessages]]protocolMessages:: <<protocolMessagesType>>
 
 .Technical name
-`NoOpEvent`
+`NoOp`
 
 .Related command
 _none_

--- a/delta/open-questions.adoc
+++ b/delta/open-questions.adoc
@@ -32,4 +32,4 @@ Example: Does <<cmd-DeleteChild>> fail if the `removedChild` does not exist? -->
 
 * Decide on errors marked with #?# (invalid optional parameter values){fn-org312} --> postponed
 
-* How to report a command has completely been discarded, without any resulting event?{fn-org314} --> NoOpEvent
+* How to report a command has completely been discarded, without any resulting event?{fn-org314} --> NoOp

--- a/delta/scenarios/changeSameValueRemoteUpdate.adoc
+++ b/delta/scenarios/changeSameValueRemoteUpdate.adoc
@@ -52,5 +52,5 @@ deactivate clientEvent
 6. Client informs editor of command submission.
 7. Repository determines no change to internal representation.
 8. Repository creates event for notification.
-9. Repository emits <<evnt-NoOpEvent>> event with <<commandSourceType>> with value `(participation-a, cmd-1)` and sequence number `1`.
+9. Repository emits <<evnt-NoOp>> event with <<commandSourceType>> with value `(participation-a, cmd-1)` and sequence number `1`.
 10. Client removes `cmd-1` from open commands list.


### PR DESCRIPTION
Also: `NoOpEvent` -> `NoOp`