### PR TITLE
Add originCommands and sequenceNumber field to CompositeEvent

### DIFF
--- a/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeCommand.adoc
+++ b/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeCommand.adoc
@@ -19,7 +19,9 @@ All other commands can be distinguished from their event counterparts by looking
 .Parameters
 [[CompositeCommand.parts, `parts`]]parts:: <<commandType>>[]
 
-[[CompositeCommand.protocolMessages]]protocolMessages:: <<protocolMessagesType>>
+[[CompositeCommand.commandId]]commandId:: <<commandIdType>>
+
+[[CompositeCommand.additionalInfos]]additionalInfos:: <<additionalInfosType>>
 
 .Errors
 * accumulation of all errors of <<CompositeCommand.parts>>

--- a/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeCommand.adoc
+++ b/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeCommand.adoc
@@ -12,10 +12,9 @@ We can nest composite commands arbitrarily.{fn-org360}
 
 Semantics:{fn-org420}
 
-* One <<cmd-CompositeCommand>> SHOULD be processed as one <<evnt-CompositeEvent>>.
-* **No** transactional semantics: all <<CompositeCommand.parts>> are processed in order and independent of the outcome of previous ones.
-** The repository MUST be in valid state after having processed each command.
-** For client implementations: nodes detached and re-attached during a composite command SHOULD keep their identity in clients — this is effectively <<reused-nodes, reusing nodes>>.
+* The repository SHOULD process one <<cmd-CompositeCommand>> as one <<evnt-CompositeEvent>>.
+* **No** transactional semantics: the repository MUST process all <<CompositeCommand.parts>> in order and independent of the outcome of previous ones.
+The repository MUST be in valid state after having processed each command.
 * If several <<cmd-CompositeCommand>>s overlap due to repository handling (e.g. conflict resolution), the behavior is **UNDEFINED**.
 
 .Technical name

--- a/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeCommand.adoc
+++ b/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeCommand.adoc
@@ -16,7 +16,7 @@ Semantics:{fn-org420}
 * **No** transactional semantics: all <<CompositeCommand.parts>> are processed in order and independent of the outcome of previous ones.
 ** The repository MUST be in valid state after having processed each command.
 ** For client implementations: nodes detached and re-attached during a composite command SHOULD keep their identity in clients.
-* Node ids can only be reused after the outermost <<cmd-CompositeCommand>> has been processed.
+* Node ids can only be <<reused-nodes, reused>> after the outermost <<cmd-CompositeCommand>> has been processed.
 * If several <<cmd-CompositeCommand>>s overlap due to repository handling (e.g. conflict resolution), the behavior is **UNDEFINED**.
 
 .Technical name

--- a/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeCommand.adoc
+++ b/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeCommand.adoc
@@ -8,6 +8,15 @@ Command groups don't guarantee anything; the repository MAY take the group as a 
 
 We can nest composite commands arbitrarily.{fn-org360}
 
+Semantics:{fn-org420}
+
+* One <<cmd-CompositeCommand>> SHOULD be processed as one <<evnt-CompositeEvent>>.
+* **No** transactional semantics: all <<CompositeCommand.parts>> are processed in order and independent of the outcome of previous ones.
+** The repo MUST be in valid state after having processed each command.
+** For client implementations: nodes detached and re-attached during a composite command SHOULD keep their identity in clients.
+* Node ids can only be reused after the outermost <<cmd-CompositeCommand>> has been processed.
+* If several <<cmd-CompositeCommand>>s overlap due to repository handling (e.g. conflict resolution), the behavior is **UNDEFINED**.
+
 .Technical name
 `CompositeCommand` footnote:[
 This command is the only one to have a `Command` suffix, which is necessary to distinguish it from its <<evnt-CompositeEvent, `CompositeEvent`>> counterpart.

--- a/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeCommand.adoc
+++ b/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeCommand.adoc
@@ -19,7 +19,7 @@ All other commands can be distinguished from their event counterparts by looking
 [[CompositeCommand.parts, `parts`]]parts:: <<commandType>>[]
 
 [[CompositeCommand.commandId]]commandId:: <<commandIdType>>
-Composite commands have their own command id, separate from the command ids of its parts/sub-commands.{fn-org353}
+Composite commands have their own command id, separate from the command ids of its <<CompositeCommand.parts>>.{fn-org353}
 
 [[CompositeCommand.additionalInfos]]additionalInfos:: <<additionalInfosType>>
 

--- a/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeCommand.adoc
+++ b/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeCommand.adoc
@@ -15,8 +15,7 @@ Semantics:{fn-org420}
 * One <<cmd-CompositeCommand>> SHOULD be processed as one <<evnt-CompositeEvent>>.
 * **No** transactional semantics: all <<CompositeCommand.parts>> are processed in order and independent of the outcome of previous ones.
 ** The repository MUST be in valid state after having processed each command.
-** For client implementations: nodes detached and re-attached during a composite command SHOULD keep their identity in clients.
-* Node ids can only be <<reused-nodes, reused>> after the outermost <<cmd-CompositeCommand>> has been processed.
+** For client implementations: nodes detached and re-attached during a composite command SHOULD keep their identity in clients — this is effectively <<reused-nodes, reusing nodes>>.
 * If several <<cmd-CompositeCommand>>s overlap due to repository handling (e.g. conflict resolution), the behavior is **UNDEFINED**.
 
 .Technical name

--- a/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeCommand.adoc
+++ b/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeCommand.adoc
@@ -6,7 +6,7 @@ The parts are ordered.
 
 Command groups don't guarantee anything; the repository MAY take the group as a hint to resolve conflicts in a different manner.
 
-Composite commands have a command id on their own.{fn-org353}
+Composite commands have their own command id, separate from the commmand ids of its parts.{fn-org353}
 We can nest composite commands arbitrarily.{fn-org360}
 
 .Technical name

--- a/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeCommand.adoc
+++ b/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeCommand.adoc
@@ -6,7 +6,6 @@ The parts are ordered.
 
 Command groups don't guarantee anything; the repository MAY take the group as a hint to resolve conflicts in a different manner.
 
-Composite commands have their own command id, separate from the commmand ids of its parts.{fn-org353}
 We can nest composite commands arbitrarily.{fn-org360}
 
 .Technical name
@@ -20,6 +19,7 @@ All other commands can be distinguished from their event counterparts by looking
 [[CompositeCommand.parts, `parts`]]parts:: <<commandType>>[]
 
 [[CompositeCommand.commandId]]commandId:: <<commandIdType>>
+Composite commands have their own command id, separate from the command ids of its parts/sub-commands.{fn-org353}
 
 [[CompositeCommand.additionalInfos]]additionalInfos:: <<additionalInfosType>>
 

--- a/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeCommand.adoc
+++ b/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeCommand.adoc
@@ -6,13 +6,15 @@ The parts are ordered.
 
 Command groups don't guarantee anything; the repository MAY take the group as a hint to resolve conflicts in a different manner.
 
+Whenever a composite command is syntactically incorrect in one of its <<CompositeCommand.parts>>, the repository MUST reject the complete composite command – as if the composite command didn’t even start executing – as the command as a whole is (deemed) syntactically incorrect.{fn-org454}
+
 We can nest composite commands arbitrarily.{fn-org360}
 
 Semantics:{fn-org420}
 
 * One <<cmd-CompositeCommand>> SHOULD be processed as one <<evnt-CompositeEvent>>.
 * **No** transactional semantics: all <<CompositeCommand.parts>> are processed in order and independent of the outcome of previous ones.
-** The repo MUST be in valid state after having processed each command.
+** The repository MUST be in valid state after having processed each command.
 ** For client implementations: nodes detached and re-attached during a composite command SHOULD keep their identity in clients.
 * Node ids can only be reused after the outermost <<cmd-CompositeCommand>> has been processed.
 * If several <<cmd-CompositeCommand>>s overlap due to repository handling (e.g. conflict resolution), the behavior is **UNDEFINED**.

--- a/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeEvent.adoc
+++ b/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeEvent.adoc
@@ -3,9 +3,9 @@
 ===== Composite
 The events in <<CompositeEvent.parts>> have happened in the given order.{fn-org281}
 
-Composite events have their own sequence number{fn-org353}, separate from the sequence numbers of its parts.{fn-351}
-(This reverses an earlier decision.{fn-org306})
 We can nest composite events arbitrarily.{fn-org360}
+
+The repository MUST NOT create composite events on its own — (only as a result of composite commands).{fn-org353}
 
 .Technical name
 `CompositeEvent` footnote:[
@@ -19,8 +19,19 @@ All other events can be distinguished from their command counterparts by looking
 [[CompositeEvent.parts, `parts`]]parts:: <<eventType>>[]
 
 [[CompositeEvent.originCommands]]originCommands:: <<commandSourceType>>[]
+The following constraints apply:{fn-org353}
++
+* The originCommands of a composite event MUST only mention command ids of composite commands.
+* Composite commands MUST only be mentioned as origins of composite events — not of their parts/sub-events.
+As an example of relations of composite command `A` with sub-command `B` (which can be a composite command!) to composite event `C` and sub-event `D` (which then could be a composite event):
++
+* `C` MUST mention `A` in its own originCommands
+* `D` MUST mention `B` in its originCommands
+* `D` MUST NOT mention `A` in its originCommands
 
 [[CompositeEvent.sequenceNumber]]sequenceNumber:: <<event-sequence-number>>
+Composite events have their own sequence number, separate from the sequence numbers of its parts/sub-events.{fn-org351}
+(This reverses an earlier decision.{fn-org306})
 
 [[CompositeEvent.additionalInfos]]additionalInfos:: <<additionalInfosType>>
 

--- a/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeEvent.adoc
+++ b/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeEvent.adoc
@@ -17,7 +17,11 @@ All other events can be distinguished from their command counterparts by looking
 .Parameters
 [[CompositeEvent.parts, `parts`]]parts:: <<eventType>>[]
 
-[[CompositeEvent.protocolMessages]]protocolMessages:: <<protocolMessagesType>>
+[[CompositeEvent.originCommands]]originCommands:: <<commandSourceType>>[]
+
+[[CompositeEvent.sequenceNumber]]sequenceNumber:: <<event-sequence-number>>
+
+[[CompositeEvent.additionalInfos]]additionalInfos:: <<additionalInfosType>>
 
 .Related command
 <<cmd-CompositeCommand>>

--- a/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeEvent.adoc
+++ b/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeEvent.adoc
@@ -17,20 +17,24 @@ All other events can be distinguished from their command counterparts by looking
 [horizontal]
 .Parameters
 [[CompositeEvent.parts, `parts`]]parts:: <<eventType>>[]
+Events contained in <<CompositeEvent.parts>> MUST appear in ascending order of their sequence numbers.{fn-org351}
 
 [[CompositeEvent.originCommands]]originCommands:: <<commandSourceType>>[]
 The following constraints apply:{fn-org353}
 +
 * The originCommands of a composite event MUST only mention command ids of composite commands.
-* Composite commands MUST only be mentioned as origins of composite events — not of their parts/sub-events.
-As an example of relations of composite command `A` with sub-command `B` (which can be a composite command!) to composite event `C` and sub-event `D` (which then could be a composite event):
+* Composite commands MUST only be mentioned as origins of composite events — not of their <<CompositeEvent.parts>>.
+As an example of relations of composite command `A` with sub-command `B` to composite event `C` and sub-event `D`:
 +
-* `C` MUST mention `A` in its own originCommands
-* `D` MUST mention `B` in its originCommands
-* `D` MUST NOT mention `A` in its originCommands
+* `C` MUST mention `A` in its own <<CompositeEvent.originCommands>>
+* `D` MUST mention `B` in its <<CompositeEvent.originCommands>>
+* `D` MUST NOT mention `A` in its <<CompositeEvent.originCommands>>
+
+(Note that command `B` can be composite, in which case event `D` would be composite as well.)
 
 [[CompositeEvent.sequenceNumber]]sequenceNumber:: <<event-sequence-number>>
-Composite events have their own sequence number, separate from the sequence numbers of its parts/sub-events.{fn-org351}
+Composite events have their own sequence number, separate from the sequence numbers of its <<CompositeEvent.parts>>.{fn-org351}
+This sequence number MUST precede the sequence numbers of all its <<CompositeEvent.parts>>.{fn-org351}
 
 [[CompositeEvent.additionalInfos]]additionalInfos:: <<additionalInfosType>>
 

--- a/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeEvent.adoc
+++ b/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeEvent.adoc
@@ -9,11 +9,11 @@ The repository MUST NOT create composite events on its own — (only as a result
 
 Semantics:{fn-org420}
 
-* A <<evnt-CompositeEvent>> SHOULD be the result of processing exactly one <<cmd-CompositeCommand>>.
-* **No** transactional semantics: all <<CompositeEvent.parts>> are processed in order and independent of the outcome of previous ones.
+. A <<evnt-CompositeEvent>> SHOULD be the result of processing exactly one <<cmd-CompositeCommand>>.
+. **No** transactional semantics: all <<CompositeEvent.parts>> are processed in order and independent of the outcome of previous ones.
 ** The repo MUST be in valid state after having processed each event.
 ** For client implementations: nodes detached and re-attached during a composite event SHOULD keep their identity in clients.
-* Node ids can only be reused after the outermost <<evnt-CompositeEvent>> has been processed.
+. Node ids can only be reused after the outermost <<evnt-CompositeEvent>> has been processed.
 
 .Technical name
 `CompositeEvent` footnote:[
@@ -30,7 +30,7 @@ Events contained in <<CompositeEvent.parts>> MUST appear in ascending order of t
 [[CompositeEvent.originCommands]]originCommands:: <<commandSourceType>>[]
 The following constraints apply:{fn-org353}
 +
-* The originCommands of a composite event MUST only mention command ids of composite commands.
+* The originCommands of a composite event MUST only mention command ids of composite commands — (owing to semantics item 1).
 * Composite commands MUST only be mentioned as origins of composite events — not of their <<CompositeEvent.parts>>.
 As an example of relations of composite command `A` with sub-command `B` to composite event `C` and sub-event `D`:
 +

--- a/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeEvent.adoc
+++ b/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeEvent.adoc
@@ -10,10 +10,9 @@ The repository MUST NOT create composite events on its own — (only as a result
 Semantics:{fn-org420}
 
 . A <<evnt-CompositeEvent>> SHOULD be the result of processing exactly one <<cmd-CompositeCommand>>.
-. **No** transactional semantics: all <<CompositeEvent.parts>> are processed in order and independent of the outcome of previous ones.
-** The repo MUST be in valid state after having processed each event.
-** For client implementations: nodes detached and re-attached during a composite event SHOULD keep their identity in clients — this is effectively <<reused-nodes, reusing nodes>>.
-* Ids of nodes that are deleted – as in: detached and not re-attached; see also <<{bulk}.adoc#deleted-nodes, this paragraph in the Bulk API>> – by any of the <<CompositeEvent.parts>> are considered free _after_ the outermost <<evnt-CompositeEvent>> has been processed.
+. **No** transactional semantics: any client MUST process all <<CompositeEvent.parts>> in order and independent of the outcome of previous ones.
+Nodes detached and re-attached during a composite event SHOULD keep their identity in clients — this is effectively <<reused-nodes, reusing nodes>>.
+* Ids of nodes that are deleted – as in: detached and not re-attached; see also <<{bulk}.adoc#deleted-nodes, this paragraph in the Bulk API>> – by any of the <<CompositeEvent.parts>> are considered free _only after_ the outermost <<evnt-CompositeEvent>> has been processed.
 
 .Technical name
 `CompositeEvent` footnote:[

--- a/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeEvent.adoc
+++ b/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeEvent.adoc
@@ -3,7 +3,8 @@
 ===== Composite
 The events in <<CompositeEvent.parts>> have happened in the given order.{fn-org281}
 
-Composite events don't mention origin commands on their own; they are only mentioned in each part.{fn-org306}
+Composite events have their own sequence number{fn-org353}, separate from the sequence numbers of its parts.{fn-351}
+(This reverses an earlier decision.{fn-org306})
 We can nest composite events arbitrarily.{fn-org360}
 
 .Technical name

--- a/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeEvent.adoc
+++ b/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeEvent.adoc
@@ -12,8 +12,8 @@ Semantics:{fn-org420}
 . A <<evnt-CompositeEvent>> SHOULD be the result of processing exactly one <<cmd-CompositeCommand>>.
 . **No** transactional semantics: all <<CompositeEvent.parts>> are processed in order and independent of the outcome of previous ones.
 ** The repo MUST be in valid state after having processed each event.
-** For client implementations: nodes detached and re-attached during a composite event SHOULD keep their identity in clients.
-. Node ids can only be reused after the outermost <<evnt-CompositeEvent>> has been processed.
+** For client implementations: nodes detached and re-attached during a composite event SHOULD keep their identity in clients — this is effectively <<reused-nodes, reusing nodes>>.
+* Ids of nodes that are deleted – as in: detached and not re-attached; see also <<{bulk}.adoc#deleted-nodes, this paragraph in the Bulk API>> – by any of the <<CompositeEvent.parts>> are considered free _after_ the outermost <<evnt-CompositeEvent>> has been processed.
 
 .Technical name
 `CompositeEvent` footnote:[

--- a/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeEvent.adoc
+++ b/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeEvent.adoc
@@ -31,7 +31,6 @@ As an example of relations of composite command `A` with sub-command `B` (which 
 
 [[CompositeEvent.sequenceNumber]]sequenceNumber:: <<event-sequence-number>>
 Composite events have their own sequence number, separate from the sequence numbers of its parts/sub-events.{fn-org351}
-(This reverses an earlier decision.{fn-org306})
 
 [[CompositeEvent.additionalInfos]]additionalInfos:: <<additionalInfosType>>
 

--- a/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeEvent.adoc
+++ b/delta/commandsEvents/miscellaneous/CompositeCommand/CompositeEvent.adoc
@@ -7,6 +7,14 @@ We can nest composite events arbitrarily.{fn-org360}
 
 The repository MUST NOT create composite events on its own — (only as a result of composite commands).{fn-org353}
 
+Semantics:{fn-org420}
+
+* A <<evnt-CompositeEvent>> SHOULD be the result of processing exactly one <<cmd-CompositeCommand>>.
+* **No** transactional semantics: all <<CompositeEvent.parts>> are processed in order and independent of the outcome of previous ones.
+** The repo MUST be in valid state after having processed each event.
+** For client implementations: nodes detached and re-attached during a composite event SHOULD keep their identity in clients.
+* Node ids can only be reused after the outermost <<evnt-CompositeEvent>> has been processed.
+
 .Technical name
 `CompositeEvent` footnote:[
 This event is the only one to have a `Event` suffix, which is necessary to distinguish it from its <<cmd-CompositeCommand, `CompositeCommand`>> counterpart.

--- a/delta/delta.schema.json
+++ b/delta/delta.schema.json
@@ -2002,6 +2002,7 @@
         }
       },
       "required": [
+        "messageKind",
         "parts",
         "commandId",
         "additionalInfos"
@@ -3273,6 +3274,12 @@
             "$ref": "#/$defs/Events"
           }
         },
+        "originCommands": {
+          "$ref": "#/$defs/commandSources"
+        },
+        "sequenceNumber": {
+          "$ref": "#/$defs/eventSequenceNumber"
+        },
         "additionalInfos": {
           "$ref": "#/$defs/additionalInfos"
         }
@@ -3280,11 +3287,13 @@
       "required": [
         "messageKind",
         "parts",
+        "originCommands",
+        "sequenceNumber",
         "additionalInfos"
       ],
       "additionalProperties": false,
-      "minProperties": 3,
-      "maxProperties": 3
+      "minProperties": 5,
+      "maxProperties": 5
     },
     "NoOpEvent": {
       "properties": {


### PR DESCRIPTION
 Also make CompositeCommand.messageKind required.
 
 I’d like to merge this PR only after I’ve gotten validation in `lionweb-integration-testing` to align between CI and local!