### PR TITLE
Add old properties to move and replace commands

### DIFF
--- a/delta/commandsEvents/annotations/MoveAndReplaceAnnotationFromOtherParent/MoveAndReplaceAnnotationFromOtherParent.adoc
+++ b/delta/commandsEvents/annotations/MoveAndReplaceAnnotationFromOtherParent/MoveAndReplaceAnnotationFromOtherParent.adoc
@@ -38,10 +38,13 @@ include::MoveAndReplaceAnnotationFromOtherParent-diagram.adoc[]
 [[MoveAndReplaceAnnotationFromOtherParent.additionalInfos]]additionalInfos:: <<additionalInfosType>>
 
 .Errors
-* <<err-unknownNode>> for <<MoveAndReplaceAnnotationFromOtherParent.newParent>>
+* <<err-unknownNode>> for <<MoveAndReplaceAnnotationFromOtherParent.newParent>> and <<MoveAndReplaceAnnotationFromOtherParent.oldParent>>
 * <<err-unknownIndex>> for <<MoveAndReplaceAnnotationFromOtherParent.newIndex>> (is beyond the number of annotations of <<MoveAndReplaceAnnotationFromOtherParent.newParent>>)
+* <<err-unknownIndex>> for <<MoveAndReplaceAnnotationFromOtherParent.oldIndex>> (is beyond the number of annotations of <<MoveAndReplaceAnnotationFromOtherParent.oldParent>>)
+* <<err-parentMismatch>> <<MoveAndReplaceAnnotationFromOtherParent.oldParent>> is not the parent of <<MoveAndReplaceAnnotationFromOtherParent.movedAnnotation>>
 * <<err-unknownNode>> for <<MoveAndReplaceAnnotationFromOtherParent.movedAnnotation>>
 * <<err-indexEntryMismatch>> for <<MoveAndReplaceAnnotationFromOtherParent.newIndex>> and <<MoveAndReplaceAnnotationFromOtherParent.replacedAnnotation>>
+* <<err-indexEntryMismatch>> for <<MoveAndReplaceAnnotationFromOtherParent.oldIndex>> and <<MoveAndReplaceAnnotationFromOtherParent.movedAnnotation>>
 * ##?## <<MoveAndReplaceAnnotationFromOtherParent.movedAnnotation>> is already an annotation of <<MoveAndReplaceAnnotationFromOtherParent.newParent>>
 * <<err-invalidParticipation>>
 

--- a/delta/commandsEvents/annotations/MoveAndReplaceAnnotationFromOtherParent/MoveAndReplaceAnnotationFromOtherParent.adoc
+++ b/delta/commandsEvents/annotations/MoveAndReplaceAnnotationFromOtherParent/MoveAndReplaceAnnotationFromOtherParent.adoc
@@ -1,6 +1,11 @@
 [[cmd-MoveAndReplaceAnnotationFromOtherParent]]
 ===== Move annotation from other parent and replace existing annotation
-Move <<existing-nodes, existing node>> <<MoveAndReplaceAnnotationFromOtherParent.movedAnnotation>> inside <<MoveAndReplaceAnnotationFromOtherParent.newParent>>'s annotations at <<MoveAndReplaceAnnotationFromOtherParent.newIndex>>.
+Move <<existing-nodes, existing node>> <<MoveAndReplaceAnnotationFromOtherParent.movedAnnotation>>
+from <<MoveAndReplaceAnnotationFromOtherParent.oldParent>>'s annotations 
+at <<MoveAndReplaceAnnotationFromOtherParent.oldIndex>> 
+to <<MoveAndReplaceAnnotationFromOtherParent.newIndex>>
+inside <<MoveAndReplaceAnnotationFromOtherParent.newParent>>'s annotations.
+
 Delete <<existing-nodes, current node>> <<MoveAndReplaceAnnotationFromOtherParent.replacedAnnotation>>{fn-org371} at <<MoveAndReplaceAnnotationFromOtherParent.newParent>>'s annotations at <<MoveAndReplaceAnnotationFromOtherParent.newIndex>>, and all its descendants (including annotation instances).
 Does NOT change references to any of the deleted nodes.{fn-org285}
 
@@ -19,6 +24,10 @@ include::MoveAndReplaceAnnotationFromOtherParent-diagram.adoc[]
 [[MoveAndReplaceAnnotationFromOtherParent.newParent, `newParent`]]newParent:: <<targetNodeType>>
 
 [[MoveAndReplaceAnnotationFromOtherParent.newIndex, `newIndex`]]newIndex:: <<indexType>>
+
+[[MoveAndReplaceAnnotationFromOtherParent.oldParent, `oldParent`]]oldParent:: <<targetNodeType>>
+
+[[MoveAndReplaceAnnotationFromOtherParent.oldIndex, `oldIndex`]]oldIndex:: <<indexType>>
 
 [[MoveAndReplaceAnnotationFromOtherParent.replacedAnnotation, `replacedAnnotation`]]replacedAnnotation:: <<targetNodeType>>
 

--- a/delta/commandsEvents/annotations/MoveAndReplaceAnnotationInSameParent/MoveAndReplaceAnnotationInSameParent.adoc
+++ b/delta/commandsEvents/annotations/MoveAndReplaceAnnotationInSameParent/MoveAndReplaceAnnotationInSameParent.adoc
@@ -1,7 +1,12 @@
 [[cmd-MoveAndReplaceAnnotationInSameParent]]
 ===== Move annotation in same parent and replace existing annotation
-Move <<existing-nodes, existing node>> <<MoveAndReplaceAnnotationInSameParent.movedAnnotation>> within the same parent to <<MoveAndReplaceAnnotationInSameParent.newIndex>>.
-Delete <<existing-nodes, current node>> <<MoveAndReplaceAnnotationInSameParent.replacedAnnotation>>{fn-org371} at <<MoveAndReplaceAnnotationInSameParent.movedAnnotation>>'s parent's annotations at <<MoveAndReplaceAnnotationInSameParent.newIndex>>, and all its descendants (including annotation instances).
+Move <<existing-nodes, existing node>> <<MoveAndReplaceAnnotationInSameParent.movedAnnotation>>
+from <<MoveAndReplaceAnnotationInSameParent.oldIndex>>
+to <<MoveAndReplaceAnnotationInSameParent.newIndex>>.
+within <<MoveAndReplaceAnnotationInSameParent.parent>>'s annotations.
+
+Delete <<existing-nodes, current node>> <<MoveAndReplaceAnnotationInSameParent.replacedAnnotation>>{fn-org371} inside <<MoveAndReplaceAnnotationInSameParent.parent>>'s
+annotations at <<MoveAndReplaceAnnotationInSameParent.newIndex>>, and all its descendants (including annotation instances).
 Does NOT change references to any of the deleted nodes.{fn-org285}
 
 [cols="a,a"]
@@ -16,7 +21,11 @@ include::MoveAndReplaceAnnotationInSameParent-diagram.adoc[]
 
 [horizontal]
 .Parameters
+[[MoveAndReplaceAnnotationInSameParent.parent, `parent`]]parent:: <<targetNodeType>>
+
 [[MoveAndReplaceAnnotationInSameParent.newIndex, `newIndex`]]newIndex:: <<indexType>>
+
+[[MoveAndReplaceAnnotationInSameParent.oldIndex, `oldIndex`]]oldIndex:: <<targetNodeType>>
 
 [[MoveAndReplaceAnnotationInSameParent.replacedAnnotation, `replacedAnnotation`]]replacedAnnotation:: <<targetNodeType>>
 

--- a/delta/commandsEvents/annotations/MoveAndReplaceAnnotationInSameParent/MoveAndReplaceAnnotationInSameParent.adoc
+++ b/delta/commandsEvents/annotations/MoveAndReplaceAnnotationInSameParent/MoveAndReplaceAnnotationInSameParent.adoc
@@ -36,8 +36,10 @@ include::MoveAndReplaceAnnotationInSameParent-diagram.adoc[]
 [[MoveAndReplaceAnnotationInSameParent.additionalInfos]]additionalInfos:: <<additionalInfosType>>
 
 .Errors
-* <<err-unknownIndex>> for <<MoveAndReplaceAnnotationInSameParent.newIndex>> (is beyond (the number of annotations of <<MoveAndReplaceAnnotationInSameParent.movedAnnotation>>'s parent) - 1)
+* <<err-unknownIndex>> for <<MoveAndReplaceAnnotationInSameParent.newIndex>> (is beyond (the number of annotations of <<MoveAndReplaceAnnotationInSameParent.parent>> - 1)
+* <<err-unknownIndex>> for <<MoveAndReplaceAnnotationInSameParent.oldIndex>> (is beyond (the number of annotations of <<MoveAndReplaceAnnotationInSameParent.parent>> - 1)
 * <<err-unknownNode>> for <<MoveAndReplaceAnnotationInSameParent.movedAnnotation>>
+* <<err-parentMismatch>> <<MoveAndReplaceAnnotationInSameParent.parent>> is not the parent of <<MoveAndReplaceAnnotationInSameParent.movedAnnotation>>
 * <<err-moveWithoutParent>> for <<MoveAndReplaceAnnotationInSameParent.movedAnnotation>>
 * <<err-indexEntryMismatch>> for <<MoveAndReplaceAnnotationInSameParent.newIndex>> and <<MoveAndReplaceAnnotationInSameParent.replacedAnnotation>>
 * <<err-invalidParticipation>>

--- a/delta/commandsEvents/annotations/MoveAnnotationFromOtherParent/MoveAnnotationFromOtherParent.adoc
+++ b/delta/commandsEvents/annotations/MoveAnnotationFromOtherParent/MoveAnnotationFromOtherParent.adoc
@@ -1,6 +1,9 @@
 [[cmd-MoveAnnotationFromOtherParent]]
 ===== Move annotation from other parent
-Move <<existing-nodes, existing node>> <<MoveAnnotationFromOtherParent.movedAnnotation>> inside <<MoveAnnotationFromOtherParent.newParent>>'s annotations at <<MoveAnnotationFromOtherParent.newIndex>>.
+Move <<existing-nodes, existing node>> <<MoveAnnotationFromOtherParent.movedAnnotation>>
+from <<MoveAnnotationFromOtherParent.oldIndex>>
+in <<MoveAnnotationFromOtherParent.oldParent>>'s annotations
+to <<MoveAnnotationFromOtherParent.newParent>>'s annotations at <<MoveAnnotationFromOtherParent.newIndex>>.
 
 [cols="a,a"]
 |===
@@ -17,6 +20,10 @@ include::MoveAnnotationFromOtherParent-diagram.adoc[]
 [[MoveAnnotationFromOtherParent.newParent, `newParent`]]newParent:: <<targetNodeType>>
 
 [[MoveAnnotationFromOtherParent.newIndex, `newIndex`]]newIndex:: <<indexType>>
+
+[[MoveAnnotationFromOtherParent.oldParent, `oldParent`]]oldParent:: <<targetNodeType>>
+
+[[MoveAnnotationFromOtherParent.oldIndex, `oldIndex`]]oldIndex:: <<indexType>>
 
 [[MoveAnnotationFromOtherParent.movedAnnotation, `movedAnnotation`]]movedAnnotation:: <<targetNodeType>>
 

--- a/delta/commandsEvents/annotations/MoveAnnotationFromOtherParent/MoveAnnotationFromOtherParent.adoc
+++ b/delta/commandsEvents/annotations/MoveAnnotationFromOtherParent/MoveAnnotationFromOtherParent.adoc
@@ -34,6 +34,8 @@ include::MoveAnnotationFromOtherParent-diagram.adoc[]
 .Errors
 * <<err-unknownNode>> for <<MoveAnnotationFromOtherParent.newParent>>
 * <<err-unknownIndex>> for <<MoveAnnotationFromOtherParent.newIndex>> (is beyond the number of annotations of <<MoveAnnotationFromOtherParent.newParent>>)
+* <<err-unknownIndex>> for <<MoveAnnotationFromOtherParent.oldIndex>> (is beyond the number of annotations of <<MoveAnnotationFromOtherParent.oldParent>>)
+* <<err-parentMismatch>> <<MoveAnnotationFromOtherParent.oldParent>> is not the parent of <<MoveAnnotationFromOtherParent.movedAnnotation>>
 * <<err-unknownNode>> for <<MoveAnnotationFromOtherParent.movedAnnotation>>
 * ##?## <<MoveAnnotationFromOtherParent.movedAnnotation>> is already an annotation of <<MoveAnnotationFromOtherParent.newParent>>
 * <<err-invalidParticipation>>

--- a/delta/commandsEvents/annotations/MoveAnnotationInSameParent/MoveAnnotationInSameParent.adoc
+++ b/delta/commandsEvents/annotations/MoveAnnotationInSameParent/MoveAnnotationInSameParent.adoc
@@ -1,6 +1,9 @@
 [[cmd-MoveAnnotationInSameParent]]
 ===== Move annotation in same parent
-Move <<existing-nodes, existing node>> <<MoveAnnotationInSameParent.movedAnnotation>> within the same parent to <<MoveAnnotationInSameParent.newIndex>>.
+Move <<existing-nodes, existing node>> <<MoveAnnotationInSameParent.movedAnnotation>>
+within <<MoveAnnotationInSameParent.parent>>
+from <<MoveAnnotationInSameParent.oldIndex>>
+to <<MoveAnnotationInSameParent.newIndex>>.
 
 [cols="a,a"]
 |===
@@ -14,7 +17,11 @@ include::MoveAnnotationInSameParent-diagram.adoc[]
 
 [horizontal]
 .Parameters
+[[MoveAnnotationInSameParent.parent, `parent`]]parent:: <<targetNodeType>>
+
 [[MoveAnnotationInSameParent.newIndex, `newIndex`]]newIndex:: <<indexType>>
+
+[[MoveAnnotationInSameParent.oldIndex, `oldIndex`]]oldIndex:: <<targetNodeType>>
 
 [[MoveAnnotationInSameParent.movedAnnotation, `movedAnnotation`]]movedAnnotation:: <<targetNodeType>>
 

--- a/delta/commandsEvents/annotations/MoveAnnotationInSameParent/MoveAnnotationInSameParent.adoc
+++ b/delta/commandsEvents/annotations/MoveAnnotationInSameParent/MoveAnnotationInSameParent.adoc
@@ -30,8 +30,11 @@ include::MoveAnnotationInSameParent-diagram.adoc[]
 [[MoveAnnotationInSameParent.additionalInfos]]additionalInfos:: <<additionalInfosType>>
 
 .Errors
-* <<err-unknownIndex>> for <<MoveAnnotationInSameParent.newIndex>> (is beyond (the number of annotations of <<MoveAnnotationInSameParent.movedAnnotation>>'s parent) - 1)
+* <<err-unknownIndex>> for <<MoveAnnotationInSameParent.newIndex>> (is beyond (the number of annotations of <<MoveAnnotationInSameParent.parent>> - 1)
+* <<err-unknownIndex>> <<MoveAnnotationInSameParent.movedAnnotation>> is not at  <<MoveAnnotationInSameParent.oldIndex>> of <<MoveAnnotationInSameParent.parent>>
+* <<err-parentMismatch>> <<MoveAnnotationInSameParent.parent>> is not the parent of <<MoveAnnotationInSameParent.movedAnnotation>>
 * <<err-unknownNode>> for <<MoveAnnotationInSameParent.movedAnnotation>>
+* <<err-unknownNode>> for <<MoveAnnotationInSameParent.parent>>
 * <<err-moveWithoutParent>> for <<MoveAnnotationInSameParent.movedAnnotation>>
 * <<err-invalidParticipation>>
 

--- a/delta/commandsEvents/children/MoveAndReplaceChildFromOtherContainment/MoveAndReplaceChildFromOtherContainment.adoc
+++ b/delta/commandsEvents/children/MoveAndReplaceChildFromOtherContainment/MoveAndReplaceChildFromOtherContainment.adoc
@@ -1,6 +1,13 @@
 [[cmd-MoveAndReplaceChildFromOtherContainment]]
 ===== Move child from other containment and replace existing child
-Move <<existing-nodes, existing node>> <<MoveAndReplaceChildFromOtherContainment.movedChild>> inside <<MoveAndReplaceChildFromOtherContainment.newParent>>'s <<MoveAndReplaceChildFromOtherContainment.newContainment>> at <<MoveAndReplaceChildFromOtherContainment.newIndex>>.
+Move <<existing-nodes, existing node>> <<MoveAndReplaceChildFromOtherContainment.movedChild>> 
+from <<MoveAndReplaceChildFromOtherContainment.oldIndex>> 
+inside <<MoveAndReplaceChildFromOtherContainment.oldParent>>'s
+<<MoveAndReplaceChildFromOtherContainment.oldContainment>>
+to <<MoveAndReplaceChildFromOtherContainment.newParent>>'s 
+<<MoveAndReplaceChildFromOtherContainment.newContainment>> at 
+<<MoveAndReplaceChildFromOtherContainment.newIndex>>.
+
 Delete <<existing-nodes, current child>> <<MoveAndReplaceChildFromOtherContainment.replacedChild>>{fn-org371} inside <<MoveAndReplaceChildFromOtherContainment.newParent>>'s <<MoveAndReplaceChildFromOtherContainment.newContainment>> at <<MoveAndReplaceChildFromOtherContainment.newIndex>>, and all its descendants (including annotation instances).
 Does NOT change references to any of the deleted nodes.{fn-org285}
 
@@ -21,6 +28,12 @@ include::MoveAndReplaceChildFromOtherContainment-diagram.adoc[]
 [[MoveAndReplaceChildFromOtherContainment.newContainment, `newContainment`]]newContainment:: <<metaPointerType>>
 
 [[MoveAndReplaceChildFromOtherContainment.newIndex, `newIndex`]]newIndex:: <<indexType>>
+
+[[MoveAndReplaceChildFromOtherContainment.oldParent, `oldParent`]]oldParent:: <<targetNodeType>>
+
+[[MoveAndReplaceChildFromOtherContainment.oldContainment, `oldContainment`]]oldContainment:: <<metaPointerType>>
+
+[[MoveAndReplaceChildFromOtherContainment.oldIndex, `oldIndex`]]oldIndex:: <<indexType>>
 
 [[MoveAndReplaceChildFromOtherContainment.replacedChild, `replacedChild`]]replacedChild:: <<targetNodeType>>
 

--- a/delta/commandsEvents/children/MoveAndReplaceChildFromOtherContainment/MoveAndReplaceChildFromOtherContainment.adoc
+++ b/delta/commandsEvents/children/MoveAndReplaceChildFromOtherContainment/MoveAndReplaceChildFromOtherContainment.adoc
@@ -45,9 +45,11 @@ include::MoveAndReplaceChildFromOtherContainment-diagram.adoc[]
 
 .Errors
 * <<err-unknownNode>> for <<MoveAndReplaceChildFromOtherContainment.newParent>>
+* <<err-unknownNode>> for <<MoveAndReplaceChildFromOtherContainment.oldParent>>
 * <<err-unknownIndex>> for <<MoveAndReplaceChildFromOtherContainment.newIndex>> (is beyond the number of <<MoveAndReplaceChildFromOtherContainment.newContainment>> entries in <<MoveAndReplaceChildFromOtherContainment.newParent>>)
 * <<err-unknownNode>> for <<MoveAndReplaceChildFromOtherContainment.movedChild>>
 * <<err-indexEntryMismatch>> for <<MoveAndReplaceChildFromOtherContainment.newContainment>>/<<MoveAndReplaceChildFromOtherContainment.newIndex>> and <<MoveAndReplaceChildFromOtherContainment.replacedChild>>
+* <<err-indexEntryMismatch>> for <<MoveAndReplaceChildFromOtherContainment.oldContainment>>/<<MoveAndReplaceChildFromOtherContainment.oldIndex>> and <<MoveAndReplaceChildFromOtherContainment.movedChild>>
 * ##?## <<MoveAndReplaceChildFromOtherContainment.movedChild>> is already a child of <<MoveAndReplaceChildFromOtherContainment.newParent>>
 * <<err-invalidParticipation>>
 

--- a/delta/commandsEvents/children/MoveAndReplaceChildFromOtherContainmentInSameParent/MoveAndReplaceChildFromOtherContainmentInSameParent.adoc
+++ b/delta/commandsEvents/children/MoveAndReplaceChildFromOtherContainmentInSameParent/MoveAndReplaceChildFromOtherContainmentInSameParent.adoc
@@ -41,9 +41,13 @@ include::MoveAndReplaceChildFromOtherContainmentInSameParent-diagram.adoc[]
 .Errors
 * <<err-unknownIndex>> for <<MoveAndReplaceChildFromOtherContainmentInSameParent.newIndex>> (is beyond the number of <<MoveAndReplaceChildFromOtherContainmentInSameParent.newContainment>> entries in <<MoveAndReplaceChildFromOtherContainmentInSameParent.movedChild>>'s parent)
 * <<err-unknownNode>> for <<MoveAndReplaceChildFromOtherContainmentInSameParent.movedChild>>
+* <<err-unknownNode>> for <<MoveAndReplaceChildFromOtherContainmentInSameParent.parent>>
 * <<err-moveWithoutParent>> for <<MoveAndReplaceChildFromOtherContainmentInSameParent.movedChild>>
 * <<err-invalidMove>> as <<MoveAndReplaceChildFromOtherContainmentInSameParent.movedChild>> is already a child inside <<MoveAndReplaceChildFromOtherContainmentInSameParent.newContainment>>
-* <<err-indexEntryMismatch>> for <<MoveAndReplaceChildFromOtherContainmentInSameParent.newContainment>>/<<MoveAndReplaceChildFromOtherContainmentInSameParent.newIndex>> and <<MoveAndReplaceChildFromOtherContainmentInSameParent.replacedChild>>
+* <<err-indexEntryMismatch>> for <<MoveAndReplaceChildFromOtherContainmentInSameParent.newContainment>>/<<MoveAndReplaceChildFromOtherContainmentInSameParent.newIndex>> and
+<<MoveAndReplaceChildFromOtherContainmentInSameParent.replacedChild>>
+* <<err-indexEntryMismatch>> for <<MoveAndReplaceChildFromOtherContainmentInSameParent.oldContainment>>/<<MoveAndReplaceChildFromOtherContainmentInSameParent.oldIndex>> and
+<<MoveAndReplaceChildFromOtherContainmentInSameParent.movedChild>>
 * <<err-invalidParticipation>>
 
 .Related event

--- a/delta/commandsEvents/children/MoveAndReplaceChildFromOtherContainmentInSameParent/MoveAndReplaceChildFromOtherContainmentInSameParent.adoc
+++ b/delta/commandsEvents/children/MoveAndReplaceChildFromOtherContainmentInSameParent/MoveAndReplaceChildFromOtherContainmentInSameParent.adoc
@@ -1,8 +1,11 @@
 [[cmd-MoveAndReplaceChildFromOtherContainmentInSameParent]]
 ===== Move child from other containment in same parent and replace existing child
-Move <<existing-nodes, existing node>> <<MoveAndReplaceChildFromOtherContainmentInSameParent.movedChild>> (currently inside one of <<MoveAndReplaceChildFromOtherContainmentInSameParent.movedChild>>'s parent's containments other than <<MoveAndReplaceChildFromOtherContainmentInSameParent.newContainment>>)
-inside <<MoveAndReplaceChildFromOtherContainmentInSameParent.movedChild>>'s parent's <<MoveAndReplaceChildFromOtherContainmentInSameParent.newContainment>> at <<MoveAndReplaceChildFromOtherContainmentInSameParent.newIndex>>.
-Delete <<existing-nodes, current child>> <<MoveAndReplaceChildFromOtherContainmentInSameParent.replacedChild>>{fn-org371} inside <<MoveAndReplaceChildFromOtherContainmentInSameParent.movedChild>>'s parent's <<MoveAndReplaceChildFromOtherContainmentInSameParent.newContainment>> at <<MoveAndReplaceChildFromOtherContainmentInSameParent.newIndex>>, and all its descendants (including annotation instances).
+Move <<existing-nodes, existing node>> <<MoveAndReplaceChildFromOtherContainmentInSameParent.movedChild>> from <<MoveAndReplaceChildFromOtherContainmentInSameParent.oldContainment>>
+at <<MoveAndReplaceChildFromOtherContainmentInSameParent.oldIndex>>
+to <<MoveAndReplaceChildFromOtherContainmentInSameParent.newContainment>> at <<MoveAndReplaceChildFromOtherContainmentInSameParent.newIndex>>.
+Both containments are in the same <<MoveAndReplaceChildFromOtherContainmentInSameParent.parent>>.
+
+Delete <<existing-nodes, current child>> <<MoveAndReplaceChildFromOtherContainmentInSameParent.replacedChild>>{fn-org371} inside <<MoveAndReplaceChildFromOtherContainmentInSameParent.parent>>'s  <<MoveAndReplaceChildFromOtherContainmentInSameParent.newContainment>> at <<MoveAndReplaceChildFromOtherContainmentInSameParent.newIndex>>, and all its descendants (including annotation instances).
 Does NOT change references to any of the deleted nodes.{fn-org285}
 
 [cols="a,a"]
@@ -17,9 +20,15 @@ include::MoveAndReplaceChildFromOtherContainmentInSameParent-diagram.adoc[]
 
 [horizontal]
 .Parameters
+[[MoveAndReplaceChildFromOtherContainmentInSameParent.parent, `parent`]]parent:: <<targetNodeType>>
+
 [[MoveAndReplaceChildFromOtherContainmentInSameParent.newContainment, `newContainment`]]newContainment:: <<metaPointerType>>
 
 [[MoveAndReplaceChildFromOtherContainmentInSameParent.newIndex, `newIndex`]]newIndex:: <<indexType>>
+
+[[MoveAndReplaceChildFromOtherContainmentInSameParent.oldContainment, `oldContainment`]]oldContainment:: <<metaPointerType>>
+
+[[MoveAndReplaceChildFromOtherContainmentInSameParent.oldIndex, `oldIndex`]]oldIndex:: <<indexType>>
 
 [[MoveAndReplaceChildFromOtherContainmentInSameParent.replacedChild, `replacedChild`]]replacedChild:: <<targetNodeType>>
 

--- a/delta/commandsEvents/children/MoveAndReplaceChildInSameContainment/MoveAndReplaceChildInSameContainment.adoc
+++ b/delta/commandsEvents/children/MoveAndReplaceChildInSameContainment/MoveAndReplaceChildInSameContainment.adoc
@@ -36,10 +36,21 @@ include::MoveAndReplaceChildInSameContainment-diagram.adoc[]
 
 .Errors
 * <<err-unknownIndex>> for <<MoveAndReplaceChildInSameContainment.newIndex>> (is beyond (the number of `<<MoveAndReplaceChildInSameContainment.movedChild>>'s containment entries in <<MoveAndReplaceChildInSameContainment.movedChild>>'s parent) - 2)
+* <<err-parentMismatch>> <<MoveAndReplaceChildInSameContainment.parent>> does not have <<MoveAndReplaceChildInSameContainment.movedChild>> as child.
 * <<err-unknownNode>> for <<MoveAndReplaceChildInSameContainment.movedChild>>
+* <<err-unknownNode>> for <<MoveAndReplaceChildInSameContainment.replacedChild>>
+* <<err-unknownNode>> for <<MoveAndReplaceChildInSameContainment.parent>>
+* <<err-parentMismatch>> The n ode <<MoveAndReplaceChildInSameContainment.parent>> does not have <<MoveAndReplaceChildInSameContainment.movedChild>> as a child.
 * <<err-moveWithoutParent>> for <<MoveAndReplaceChildInSameContainment.movedChild>>
+* <<err-indexEntryMismatch>> for <<MoveAndReplaceChildInSameContainment.containment>>/<<MoveAndReplaceChildInSameContainment.oldIndex>> 
+and <<MoveAndReplaceChildInSameContainment.movedChild>>
+* <<err-indexEntryMismatch>> for <<MoveAndReplaceChildInSameContainment.containment>>/<<MoveAndReplaceChildInSameContainment.oldIndex>>
+and <<MoveAndReplaceChildInSameContainment.movedChild>>
+* <<err-indexEntryMismatch>> for <<MoveAndReplaceChildInSameContainment.containment>>/<<MoveAndReplaceChildInSameContainment.newIndex>>
+and <<MoveAndReplaceChildInSameContainment.replacedChild>>
 * <<err-invalidMove>> as <<MoveAndReplaceChildInSameContainment.movedChild>> is already at <<MoveAndReplaceChildInSameContainment.newIndex>>
 * <<err-indexEntryMismatch>> for <<MoveAndReplaceChildInSameContainment.newIndex>> and <<MoveAndReplaceChildInSameContainment.replacedChild>>
+* <<err-indexEntryMismatch>> for <<MoveAndReplaceChildInSameContainment.oldIndex>> and <<MoveAndReplaceChildInSameContainment.movedChild>>
 * <<err-invalidParticipation>>
 
 .Related event

--- a/delta/commandsEvents/children/MoveAndReplaceChildInSameContainment/MoveAndReplaceChildInSameContainment.adoc
+++ b/delta/commandsEvents/children/MoveAndReplaceChildInSameContainment/MoveAndReplaceChildInSameContainment.adoc
@@ -1,7 +1,9 @@
 [[cmd-MoveAndReplaceChildInSameContainment]]
 ===== Move child in same containment and replace existing child
-Move <<existing-nodes, existing node>> <<MoveAndReplaceChildInSameContainment.movedChild>> within its current containment to <<MoveAndReplaceChildInSameContainment.newIndex>>.
-Delete <<existing-nodes, current child>> <<MoveAndReplaceChildInSameContainment.replacedChild>>{fn-org371} inside the same containment at <<MoveAndReplaceChildInSameContainment.newIndex>>, and all its descendants (including annotation instances).
+Move <<existing-nodes, existing node>> <<MoveAndReplaceChildInSameContainment.movedChild>> within <<MoveAndReplaceChildInSameContainment.containment>> from <<MoveAndReplaceChildInSameContainment.oldIndex>> to <<MoveAndReplaceChildInSameContainment.newIndex>>.
+The containment is inside <<MoveAndReplaceChildInSameContainment.parent>>.
+
+Delete <<existing-nodes, current child>> <<MoveAndReplaceChildInSameContainment.replacedChild>>{fn-org371} inside <<MoveAndReplaceChildInSameContainment.containment>> at <<MoveAndReplaceChildInSameContainment.newIndex>>, and all its descendants (including annotation instances).
 Does NOT change references to any of the deleted nodes.{fn-org285}
 
 [cols="a,a"]
@@ -16,7 +18,13 @@ include::MoveAndReplaceChildInSameContainment-diagram.adoc[]
 
 [horizontal]
 .Parameters
+[[MoveAndReplaceChildInSameContainment.parent, `parent`]]parent:: <<targetNodeType>>
+
+[[MoveAndReplaceChildInSameContainment.containment, `containment`]]containment:: <<metaPointerType>>
+
 [[MoveAndReplaceChildInSameContainment.newIndex, `newIndex`]]newIndex:: <<indexType>>
+
+[[MoveAndReplaceChildInSameContainment.oldIndex, `oldIndex`]]oldIndex:: <<indexType>>
 
 [[MoveAndReplaceChildInSameContainment.replacedChild, `replacedChild`]]replacedChild:: <<targetNodeType>>
 

--- a/delta/commandsEvents/children/MoveChildFromOtherContainment/MoveChildFromOtherContainment.adoc
+++ b/delta/commandsEvents/children/MoveChildFromOtherContainment/MoveChildFromOtherContainment.adoc
@@ -1,6 +1,9 @@
 [[cmd-MoveChildFromOtherContainment]]
 ===== Move child from other containment
-Move <<existing-nodes, existing node>> <<MoveChildFromOtherContainment.movedChild>> inside <<MoveChildFromOtherContainment.newParent>>'s <<MoveChildFromOtherContainment.newContainment>> at <<MoveChildFromOtherContainment.newIndex>>.
+Move <<existing-nodes, existing node>> <<MoveChildFromOtherContainment.movedChild>>
+from <<MoveChildFromOtherContainment.oldContainment>> at <<MoveChildFromOtherContainment.oldIndex>>
+in <<MoveChildFromOtherContainment.oldParent>>
+to <<MoveChildFromOtherContainment.newParent>>'s <<MoveChildFromOtherContainment.newContainment>> at <<MoveChildFromOtherContainment.newIndex>>.
 
 [cols="a,a"]
 |===
@@ -19,6 +22,12 @@ include::MoveChildFromOtherContainment-diagram.adoc[]
 [[MoveChildFromOtherContainment.newContainment, `newContainment`]]newContainment:: <<metaPointerType>>
 
 [[MoveChildFromOtherContainment.newIndex, `newIndex`]]newIndex:: <<indexType>>
+
+[[MoveChildFromOtherContainment.oldParent, `oldParent`]]oldParent:: <<targetNodeType>>
+
+[[MoveChildFromOtherContainment.oldContainment, `oldContainment`]]oldContainment:: <<metaPointerType>>
+
+[[MoveChildFromOtherContainment.oldIndex, `oldIndex`]]oldIndex:: <<indexType>>
 
 [[MoveChildFromOtherContainment.movedChild, `movedChild`]]movedChild:: <<targetNodeType>>
 

--- a/delta/commandsEvents/children/MoveChildFromOtherContainment/MoveChildFromOtherContainment.adoc
+++ b/delta/commandsEvents/children/MoveChildFromOtherContainment/MoveChildFromOtherContainment.adoc
@@ -36,7 +36,13 @@ include::MoveChildFromOtherContainment-diagram.adoc[]
 [[MoveChildFromOtherContainment.additionalInfos]]additionalInfos:: <<additionalInfosType>>
 
 .Errors
-* <<err-nodeAlreadyExists>> for <<MoveChildFromOtherContainment.newParent>>
+* <<err-unknownNode>> for <<MoveChildFromOtherContainment.oldParent>>
+* <<err-unknownNode>> for <<MoveChildFromOtherContainment.newParent>>
+* <<err-unknownNode>> for <<MoveChildFromOtherContainment.movedChild>>
+* <<err-parentMismatch>> The node <<MoveChildFromOtherContainment.oldParent>> does not have 
+<<MoveChildFromOtherContainment.movedChild>> as child.
+* <<err-indexEntryMismatch>> for <<MoveChildFromOtherContainment.oldContainment>>/<<MoveChildFromOtherContainment.oldIndex>> and
+<<MoveChildFromOtherContainment.movedChild>>
 * <<err-unknownIndex>> for <<MoveChildFromOtherContainment.newIndex>> (is beyond the number of <<MoveChildFromOtherContainment.newContainment>> entries in <<MoveChildFromOtherContainment.newParent>>)
 * <<err-unknownNode>> for <<MoveChildFromOtherContainment.movedChild>>
 * ##?## <<MoveChildFromOtherContainment.movedChild>> is already a child of <<MoveChildFromOtherContainment.newParent>>

--- a/delta/commandsEvents/children/MoveChildFromOtherContainmentInSameParent/MoveChildFromOtherContainmentInSameParent.adoc
+++ b/delta/commandsEvents/children/MoveChildFromOtherContainmentInSameParent/MoveChildFromOtherContainmentInSameParent.adoc
@@ -1,7 +1,11 @@
 [[cmd-MoveChildFromOtherContainmentInSameParent]]
 ===== Move child from other containment in same parent
-Move <<existing-nodes, existing node>> <<MoveChildFromOtherContainmentInSameParent.movedChild>> (currently inside one of <<MoveChildFromOtherContainmentInSameParent.movedChild>>'s parent's containments other than <<MoveChildFromOtherContainmentInSameParent.newContainment>>)
-inside <<MoveChildFromOtherContainmentInSameParent.movedChild>>'s parent's <<MoveChildFromOtherContainmentInSameParent.newContainment>> at <<MoveChildFromOtherContainmentInSameParent.newIndex>>.
+Move <<existing-nodes, existing node>> <<MoveChildFromOtherContainmentInSameParent.movedChild>>
+from <<MoveChildFromOtherContainmentInSameParent.oldContainment>>
+at <<MoveChildFromOtherContainmentInSameParent.oldIndex>>
+to <<MoveChildFromOtherContainmentInSameParent.newContainment>> 
+at <<MoveChildFromOtherContainmentInSameParent.newIndex>>.
+Both containments are inside <<MoveChildFromOtherContainmentInSameParent.parent>>.
 
 [cols="a,a"]
 |===
@@ -15,9 +19,15 @@ include::MoveChildFromOtherContainmentInSameParent-diagram.adoc[]
 
 [horizontal]
 .Parameters
+[[MoveChildFromOtherContainmentInSameParent.parent, `parent`]]parent:: <<targetNodeType>>
+
 [[MoveChildFromOtherContainmentInSameParent.newContainment, `newContainment`]]newContainment:: <<metaPointerType>>
 
 [[MoveChildFromOtherContainmentInSameParent.newIndex, `newIndex`]]newIndex:: <<indexType>>
+
+[[MoveChildFromOtherContainmentInSameParent.oldContainment, `oldContainment`]]oldContainment:: <<metaPointerType>>
+
+[[MoveChildFromOtherContainmentInSameParent.oldIndex, `oldIndex`]]oldIndex:: <<indexType>>
 
 [[MoveChildFromOtherContainmentInSameParent.movedChild, `movedChild`]]movedChild:: <<targetNodeType>>
 

--- a/delta/commandsEvents/children/MoveChildFromOtherContainmentInSameParent/MoveChildFromOtherContainmentInSameParent.adoc
+++ b/delta/commandsEvents/children/MoveChildFromOtherContainmentInSameParent/MoveChildFromOtherContainmentInSameParent.adoc
@@ -38,6 +38,7 @@ include::MoveChildFromOtherContainmentInSameParent-diagram.adoc[]
 .Errors
 * <<err-unknownIndex>> for <<MoveChildFromOtherContainmentInSameParent.newIndex>> (is beyond the number of <<MoveChildFromOtherContainmentInSameParent.newContainment>> entries in <<MoveChildFromOtherContainmentInSameParent.movedChild>>'s parent)
 * <<err-unknownNode>> for <<MoveChildFromOtherContainmentInSameParent.movedChild>>
+* <<err-unknownNode>> for <<MoveChildFromOtherContainmentInSameParent.parent>>
 * <<err-moveWithoutParent>> for <<MoveChildFromOtherContainmentInSameParent.movedChild>>
 * <<err-invalidMove>> as <<MoveChildFromOtherContainmentInSameParent.movedChild>> is already a child inside <<MoveChildFromOtherContainmentInSameParent.newContainment>>
 * <<err-invalidParticipation>>

--- a/delta/commandsEvents/children/MoveChildInSameContainment/MoveChildInSameContainment.adoc
+++ b/delta/commandsEvents/children/MoveChildInSameContainment/MoveChildInSameContainment.adoc
@@ -33,9 +33,12 @@ include::MoveChildInSameContainment-diagram.adoc[]
 [[MoveChildInSameContainment.additionalInfos]]additionalInfos:: <<additionalInfosType>>
 
 .Errors
-* <<err-unknownIndex>> for <<MoveChildInSameContainment.newIndex>> (is beyond (the number of <<MoveChildInSameContainment.movedChild>>'s containment entries in <<MoveChildInSameContainment.movedChild>>'s parent) - 1)
+* <<err-unknownIndex>> for <<MoveChildInSameContainment.newIndex>> (is beyond (the number of containment entries in <<MoveChildInSameContainment.containment>> - 1)
 * <<err-unknownNode>> for <<MoveChildInSameContainment.movedChild>>
+* <<err-unknownNode>> for <<MoveChildInSameContainment.parent>>
 * <<err-moveWithoutParent>> for <<MoveChildInSameContainment.movedChild>>
+* <<err-indexEntryMismatch>> for <<MoveChildInSameContainment.containment>>/<<MoveChildInSameContainment.oldIndex>> and
+<<MoveChildInSameContainment.movedChild>>
 * <<err-invalidMove>> as <<MoveChildInSameContainment.movedChild>> is already at <<MoveChildInSameContainment.newIndex>>
 * <<err-invalidParticipation>>
 

--- a/delta/commandsEvents/children/MoveChildInSameContainment/MoveChildInSameContainment.adoc
+++ b/delta/commandsEvents/children/MoveChildInSameContainment/MoveChildInSameContainment.adoc
@@ -1,6 +1,10 @@
 [[cmd-MoveChildInSameContainment]]
 ===== Move child in same containment
-Move <<existing-nodes, existing node>> <<MoveChildInSameContainment.movedChild>> within its current containment to <<MoveChildInSameContainment.newIndex>>.
+Move <<existing-nodes, existing node>> <<MoveChildInSameContainment.movedChild>>
+within its current <<MoveChildInSameContainment.containment>>
+from <<MoveChildInSameContainment.oldIndex>>
+to <<MoveChildInSameContainment.newIndex>>.
+The containment is inside <<MoveChildInSameContainment.parent>>.
 
 [cols="a,a"]
 |===
@@ -14,7 +18,13 @@ include::MoveChildInSameContainment-diagram.adoc[]
 
 [horizontal]
 .Parameters
+[[MoveChildInSameContainment.parent, `parent`]]parent:: <<targetNodeType>>
+
 [[MoveChildInSameContainment.newIndex, `newIndex`]]newIndex:: <<indexType>>
+
+[[MoveChildInSameContainment.containment, `containment`]]containment:: <<metaPointerType>>
+
+[[MoveChildInSameContainment.oldIndex, `oldIndex`]]oldIndex:: <<indexType>>
 
 [[MoveChildInSameContainment.movedChild, `movedChild`]]movedChild:: <<targetNodeType>>
 

--- a/delta/delta.schema.json
+++ b/delta/delta.schema.json
@@ -1489,6 +1489,15 @@
         "newIndex": {
           "$ref": "#/$defs/index"
         },
+        "oldParent": {
+          "$ref": "#/$defs/targetNode"
+        },
+        "oldContainment": {
+          "$ref": "#/$defs/metaPointer"
+        },
+        "oldIndex": {
+          "$ref": "#/$defs/index"
+        },
         "movedChild": {
           "$ref": "#/$defs/targetNode"
         },
@@ -1504,18 +1513,24 @@
         "newParent",
         "newContainment",
         "newIndex",
+        "oldParent",
+        "oldIndex",
+        "oldContainment",
         "movedChild",
         "commandId",
         "additionalInfos"
       ],
       "additionalProperties": false,
-      "minProperties": 7,
-      "maxProperties": 7
+      "minProperties": 10,
+      "maxProperties": 10
     },
     "MoveChildFromOtherContainmentInSameParent": {
       "properties": {
         "messageKind": {
           "const": "MoveChildFromOtherContainmentInSameParent"
+        },
+        "parent": {
+          "$ref": "#/$defs/targetNode"
         },
         "newContainment": {
           "$ref": "#/$defs/metaPointer"
@@ -1523,34 +1538,10 @@
         "newIndex": {
           "$ref": "#/$defs/index"
         },
-        "movedChild": {
-          "$ref": "#/$defs/targetNode"
+        "oldContainment": {
+          "$ref": "#/$defs/metaPointer"
         },
-        "commandId": {
-          "$ref": "#/$defs/commandId"
-        },
-        "additionalInfos": {
-          "$ref": "#/$defs/additionalInfos"
-        }
-      },
-      "required": [
-        "messageKind",
-        "newContainment",
-        "newIndex",
-        "movedChild",
-        "commandId",
-        "additionalInfos"
-      ],
-      "additionalProperties": false,
-      "minProperties": 6,
-      "maxProperties": 6
-    },
-    "MoveChildInSameContainment": {
-      "properties": {
-        "messageKind": {
-          "const": "MoveChildInSameContainment"
-        },
-        "newIndex": {
+        "oldIndex": {
           "$ref": "#/$defs/index"
         },
         "movedChild": {
@@ -1565,14 +1556,59 @@
       },
       "required": [
         "messageKind",
+        "parent",
+        "newContainment",
         "newIndex",
+        "oldContainment",
+        "oldIndex",
         "movedChild",
         "commandId",
         "additionalInfos"
       ],
       "additionalProperties": false,
-      "minProperties": 5,
-      "maxProperties": 5
+      "minProperties": 9,
+      "maxProperties": 9
+    },
+    "MoveChildInSameContainment": {
+      "properties": {
+        "messageKind": {
+          "const": "MoveChildInSameContainment"
+        },
+        "parent": {
+          "$ref": "#/$defs/targetNode"
+        },
+        "containment": {
+          "$ref": "#/$defs/metaPointer"
+        },
+        "newIndex": {
+          "$ref": "#/$defs/index"
+        },
+        "oldIndex": {
+          "$ref": "#/$defs/index"
+        },
+        "movedChild": {
+          "$ref": "#/$defs/targetNode"
+        },
+        "commandId": {
+          "$ref": "#/$defs/commandId"
+        },
+        "additionalInfos": {
+          "$ref": "#/$defs/additionalInfos"
+        }
+      },
+      "required": [
+        "messageKind",
+        "parent",
+        "containment",
+        "newIndex",
+        "oldIndex",
+        "movedChild",
+        "commandId",
+        "additionalInfos"
+      ],
+      "additionalProperties": false,
+      "minProperties": 8,
+      "maxProperties": 8
     },
     "MoveAndReplaceChildFromOtherContainment": {
       "properties": {
@@ -1588,6 +1624,15 @@
         "newIndex": {
           "$ref": "#/$defs/index"
         },
+        "oldParent": {
+          "$ref": "#/$defs/targetNode"
+        },
+        "oldContainment": {
+          "$ref": "#/$defs/metaPointer"
+        },
+        "oldIndex": {
+          "$ref": "#/$defs/index"
+        },
         "replacedChild": {
           "$ref": "#/$defs/targetNode"
         },
@@ -1606,19 +1651,25 @@
         "newParent",
         "newContainment",
         "newIndex",
+        "oldParent",
+        "oldContainment",
+        "oldIndex",
         "replacedChild",
         "movedChild",
         "commandId",
         "additionalInfos"
       ],
       "additionalProperties": false,
-      "minProperties": 8,
-      "maxProperties": 8
+      "minProperties": 11,
+      "maxProperties": 11
     },
     "MoveAndReplaceChildFromOtherContainmentInSameParent": {
       "properties": {
         "messageKind": {
           "const": "MoveAndReplaceChildFromOtherContainmentInSameParent"
+        },
+        "parent": {
+          "$ref": "#/$defs/targetNode"
         },
         "newContainment": {
           "$ref": "#/$defs/metaPointer"
@@ -1626,38 +1677,10 @@
         "newIndex": {
           "$ref": "#/$defs/index"
         },
-        "replacedChild": {
-          "$ref": "#/$defs/targetNode"
+        "oldContainment": {
+          "$ref": "#/$defs/metaPointer"
         },
-        "movedChild": {
-          "$ref": "#/$defs/targetNode"
-        },
-        "commandId": {
-          "$ref": "#/$defs/commandId"
-        },
-        "additionalInfos": {
-          "$ref": "#/$defs/additionalInfos"
-        }
-      },
-      "required": [
-        "messageKind",
-        "newContainment",
-        "newIndex",
-        "replacedChild",
-        "movedChild",
-        "commandId",
-        "additionalInfos"
-      ],
-      "additionalProperties": false,
-      "minProperties": 7,
-      "maxProperties": 7
-    },
-    "MoveAndReplaceChildInSameContainment": {
-      "properties": {
-        "messageKind": {
-          "const": "MoveAndReplaceChildInSameContainment"
-        },
-        "newIndex": {
+        "oldIndex": {
           "$ref": "#/$defs/index"
         },
         "replacedChild": {
@@ -1675,15 +1698,64 @@
       },
       "required": [
         "messageKind",
+        "parent",
+        "newContainment",
         "newIndex",
+        "oldContainment",
+        "oldIndex",
         "replacedChild",
         "movedChild",
         "commandId",
         "additionalInfos"
       ],
       "additionalProperties": false,
-      "minProperties": 6,
-      "maxProperties": 6
+      "minProperties": 10,
+      "maxProperties": 10
+    },
+    "MoveAndReplaceChildInSameContainment": {
+      "properties": {
+        "messageKind": {
+          "const": "MoveAndReplaceChildInSameContainment"
+        },
+        "parent": {
+          "$ref": "#/$defs/targetNode"
+        },
+        "containment": {
+          "$ref": "#/$defs/metaPointer"
+        },
+        "newIndex": {
+          "$ref": "#/$defs/index"
+        },
+        "oldIndex": {
+          "$ref": "#/$defs/index"
+        },
+        "replacedChild": {
+          "$ref": "#/$defs/targetNode"
+        },
+        "movedChild": {
+          "$ref": "#/$defs/targetNode"
+        },
+        "commandId": {
+          "$ref": "#/$defs/commandId"
+        },
+        "additionalInfos": {
+          "$ref": "#/$defs/additionalInfos"
+        }
+      },
+      "required": [
+        "messageKind",
+        "parent",
+        "containment",
+        "newIndex",
+        "oldIndex",
+        "replacedChild",
+        "movedChild",
+        "commandId",
+        "additionalInfos"
+      ],
+      "additionalProperties": false,
+      "minProperties": 9,
+      "maxProperties": 9
     },
     "AddAnnotation": {
       "properties": {
@@ -1805,34 +1877,10 @@
         "newIndex": {
           "$ref": "#/$defs/index"
         },
-        "movedAnnotation": {
+        "oldParent": {
           "$ref": "#/$defs/targetNode"
         },
-        "commandId": {
-          "$ref": "#/$defs/commandId"
-        },
-        "additionalInfos": {
-          "$ref": "#/$defs/additionalInfos"
-        }
-      },
-      "required": [
-        "messageKind",
-        "newParent",
-        "newIndex",
-        "movedAnnotation",
-        "commandId",
-        "additionalInfos"
-      ],
-      "additionalProperties": false,
-      "minProperties": 6,
-      "maxProperties": 6
-    },
-    "MoveAnnotationInSameParent": {
-      "properties": {
-        "messageKind": {
-          "const": "MoveAnnotationInSameParent"
-        },
-        "newIndex": {
+        "oldIndex": {
           "$ref": "#/$defs/index"
         },
         "movedAnnotation": {
@@ -1847,14 +1895,54 @@
       },
       "required": [
         "messageKind",
+        "newParent",
         "newIndex",
+        "oldParent",
+        "oldIndex",
         "movedAnnotation",
         "commandId",
         "additionalInfos"
       ],
       "additionalProperties": false,
-      "minProperties": 5,
-      "maxProperties": 5
+      "minProperties": 8,
+      "maxProperties": 8
+    },
+    "MoveAnnotationInSameParent": {
+      "properties": {
+        "messageKind": {
+          "const": "MoveAnnotationInSameParent"
+        },
+        "parent": {
+          "$ref": "#/$defs/targetNode"
+        },
+        "newIndex": {
+          "$ref": "#/$defs/index"
+        },
+        "oldIndex": {
+          "$ref": "#/$defs/index"
+        },
+        "movedAnnotation": {
+          "$ref": "#/$defs/targetNode"
+        },
+        "commandId": {
+          "$ref": "#/$defs/commandId"
+        },
+        "additionalInfos": {
+          "$ref": "#/$defs/additionalInfos"
+        }
+      },
+      "required": [
+        "messageKind",
+        "parent",
+        "newIndex",
+        "oldIndex",
+        "movedAnnotation",
+        "commandId",
+        "additionalInfos"
+      ],
+      "additionalProperties": false,
+      "minProperties": 7,
+      "maxProperties": 7
     },
     "MoveAndReplaceAnnotationFromOtherParent": {
       "properties": {
@@ -1867,38 +1955,10 @@
         "newIndex": {
           "$ref": "#/$defs/index"
         },
-        "replacedAnnotation": {
+        "oldParent": {
           "$ref": "#/$defs/targetNode"
         },
-        "movedAnnotation": {
-          "$ref": "#/$defs/targetNode"
-        },
-        "commandId": {
-          "$ref": "#/$defs/commandId"
-        },
-        "additionalInfos": {
-          "$ref": "#/$defs/additionalInfos"
-        }
-      },
-      "required": [
-        "messageKind",
-        "newParent",
-        "newIndex",
-        "replacedAnnotation",
-        "movedAnnotation",
-        "commandId",
-        "additionalInfos"
-      ],
-      "additionalProperties": false,
-      "minProperties": 7,
-      "maxProperties": 7
-    },
-    "MoveAndReplaceAnnotationInSameParent": {
-      "properties": {
-        "messageKind": {
-          "const": "MoveAndReplaceAnnotationInSameParent"
-        },
-        "newIndex": {
+        "oldIndex": {
           "$ref": "#/$defs/index"
         },
         "replacedAnnotation": {
@@ -1916,15 +1976,59 @@
       },
       "required": [
         "messageKind",
+        "newParent",
         "newIndex",
+        "oldParent",
+        "oldIndex",
         "replacedAnnotation",
         "movedAnnotation",
         "commandId",
         "additionalInfos"
       ],
       "additionalProperties": false,
-      "minProperties": 6,
-      "maxProperties": 6
+      "minProperties": 9,
+      "maxProperties": 9
+    },
+    "MoveAndReplaceAnnotationInSameParent": {
+      "properties": {
+        "messageKind": {
+          "const": "MoveAndReplaceAnnotationInSameParent"
+        },
+        "parent": {
+          "$ref": "#/$defs/targetNode"
+        },
+        "newIndex": {
+          "$ref": "#/$defs/index"
+        },
+        "oldIndex": {
+          "$ref": "#/$defs/index"
+        },
+        "replacedAnnotation": {
+          "$ref": "#/$defs/targetNode"
+        },
+        "movedAnnotation": {
+          "$ref": "#/$defs/targetNode"
+        },
+        "commandId": {
+          "$ref": "#/$defs/commandId"
+        },
+        "additionalInfos": {
+          "$ref": "#/$defs/additionalInfos"
+        }
+      },
+      "required": [
+        "messageKind",
+        "parent",
+        "newIndex",
+        "oldIndex",
+        "replacedAnnotation",
+        "movedAnnotation",
+        "commandId",
+        "additionalInfos"
+      ],
+      "additionalProperties": false,
+      "minProperties": 8,
+      "maxProperties": 8
     },
     "AddReference": {
       "properties": {

--- a/delta/errors.adoc
+++ b/delta/errors.adoc
@@ -54,7 +54,8 @@ Client provided a node with a parent, but the parent node does not exist.
 
 [[err-parentMismatch]]
 ==== The given parent of a node is not its parent 
-Client provided an existing node with a parent, but the parent does not have the node as a child (annotation or containment).
+Client provided an existing node N with a parent id in its parent property, but the node with this parent-id
+does not have the existing node N as a child (annotation or containment).
 
 .Technical name
 `parentMismatch`

--- a/delta/errors.adoc
+++ b/delta/errors.adoc
@@ -45,6 +45,19 @@ Client provided an entry (either a node or a target/resolveInfo) and an index, b
 .Technical name
 `indexNodeMismatch`
 
+[[err-unknownParentNode]]
+==== The parent of a node does not exist 
+Client provided a node with a parent, but the parent node does not exist.
+
+.Technical name
+`unknownParentNode`
+
+[[err-parentMismatch]]
+==== The given parent of a node is not its parent 
+Client provided an existing node with a parent, but the parent does not have the node as a child (annotation or containment).
+
+.Technical name
+`parentMismatch`
 
 [[err-moveWithoutParent]]
 ==== Move without parent


### PR DESCRIPTION
Added properties to both the spec document and the SJON schema for the Move/MoveAndReplace commands.
I did ***not*** do a complete check for all commands to become similar to their events.