### PR TITLE
Missed two misspelled "datatype"s

### DIFF
--- a/2024.1/index.adoc
+++ b/2024.1/index.adoc
@@ -90,3 +90,10 @@ include::metametamodel/lioncore.json[lines=2151..2157]
 ----
 
 They both MUST be the same, i.e. `-id-IKeyed-key-2024-1`.
+
+=== Misspelling of “data type”
+
+The official, correct spelling of “data type” is as two words.
+Version 2024.1 of the serialization specification uses “datatype” in various places.
+This has been left in as this version has been published.
+

--- a/2024.1/serialization/serialization.adoc
+++ b/2024.1/serialization/serialization.adoc
@@ -287,7 +287,8 @@ Booleans MUST NOT be encoded with leading or trailing whitespace, uppercase char
 * `"-6 "`
 
 [[structuredDatatype]]
-==== Structured Datatype
+[[structuredDataType]]
+==== Structured Data Type
 <<{m3}.adoc#StructuredDataType, LionCore StructuredDataType>> MUST be encoded as JSON _string_.
 The string contains a JSON _object_ according to spec (RFC 8259) with proper escaping: all double quotes, line breaks, etc. MUST be escaped to form a proper JSON _string_.
 

--- a/2024.1/serialization/serialization.adoc
+++ b/2024.1/serialization/serialization.adoc
@@ -287,8 +287,7 @@ Booleans MUST NOT be encoded with leading or trailing whitespace, uppercase char
 * `"-6 "`
 
 [[structuredDatatype]]
-[[structuredDataType]]
-==== Structured Data Type
+==== Structured Datatype
 <<{m3}.adoc#StructuredDataType, LionCore StructuredDataType>> MUST be encoded as JSON _string_.
 The string contains a JSON _object_ according to spec (RFC 8259) with proper escaping: all double quotes, line breaks, etc. MUST be escaped to form a proper JSON _string_.
 

--- a/2024.1/serialization/serialization.adoc
+++ b/2024.1/serialization/serialization.adoc
@@ -297,7 +297,7 @@ Each <<{m3}.adoc#Field, Field>> forms one _member_, with the field's <<{m3}.adoc
 For fields of type <<string>>, <<boolean>>, <<integer>>, and <<literal>>, the _value_ is encoded as JSON _string_ in the same way as for a property.
 For fields of type <<structuredDatatype>>, the value is encoded as JSON _object_.
 
-.Structured data types used in the examples
+.Structured datatypes used in the examples
 --
 
 NOTE: The format used in this example is non-normative.
@@ -308,16 +308,16 @@ enumeration Currency                   [id aa, key currency]
   literal EUR                          [id a0, key cur-eur]
   literal GBP                          [id a1, key cur-gbp]
 
-structured data type Amount             [id 10, key amount]
+structured datatype Amount             [id 10, key amount]
   value: Integer                       [id 11, key amount-val]
   currency: Currency                   [id 12, key amount-cur]
   digital: Boolean                     [id 13, key digital]
 
-structured data type Decimal            [id 20, key decimal]
+structured datatype Decimal            [id 20, key decimal]
   int: Integer                         [id 21, key decimal-int]
   frac: Integer                        [id 22, key decimal-frac]
 
-structured data type ComplexNumber      [id 30, key complex]
+structured datatype ComplexNumber      [id 30, key complex]
   real: Decimal                        [id 31, key complex-real]
   imaginary: Decimal                   [id 32, key complex-imaginary]
 ----
@@ -426,7 +426,7 @@ unescaped content:
 {"decimal-int": "42", "decimal-frac": "0", "decimal-comment": "life question?"}
 ----
 
-* ComplexNumber with recursively nested structured data type: `"{\n\"complex-real\": \"{ \\\"decimal-int\\\": \\\"23\\\", \\\"decimal-frac\\\": \\\"17\\\"}\",\n\"complex-imaginary\": { \"decimal-int\": \"42\", \"decimal-frac\": \"0\"}\n}"`
+* ComplexNumber with recursively nested structured datatype: `"{\n\"complex-real\": \"{ \\\"decimal-int\\\": \\\"23\\\", \\\"decimal-frac\\\": \\\"17\\\"}\",\n\"complex-imaginary\": { \"decimal-int\": \"42\", \"decimal-frac\": \"0\"}\n}"`
 +
 unescaped content:
 +
@@ -568,7 +568,7 @@ This section lists all versions as they appear in <<SerializationChunk.serializa
 === 2024.1
 Technical name: `2024.1`
 
-* Repurposed `JSON` primitive data type serialization for <<{m3}.adoc#StructuredDataType, StructuredDataType>>
+* Repurposed `JSON` primitive datatype serialization for <<{m3}.adoc#StructuredDataType, StructuredDataType>>
 
 Refer to <<{roadmap}.adoc#release-2024.1, roadmap>> for details.
 

--- a/serialization/serialization.adoc
+++ b/serialization/serialization.adoc
@@ -289,7 +289,8 @@ An implementation MAY refuse a model containing an integer value outside the sup
 * `"-6 "`
 
 [[structuredDatatype]]
-==== Structured Datatype
+[[structuredDataType]]
+==== Structured Data Type
 <<{m3}.adoc#StructuredDataType, LionCore StructuredDataType>> MUST be encoded as JSON _string_.
 The string contains a JSON _object_ according to spec (RFC 8259) with proper escaping: all double quotes, line breaks, etc. MUST be escaped to form a proper JSON _string_.
 


### PR DESCRIPTION
(Well, the same one really.)
Not sure we want to change the (published) 2024.1 spec.